### PR TITLE
dockerize app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM maven:3.8.3-openjdk-17 as build
+WORKDIR /app
+COPY pom.xml ./pom.xml
+COPY src ./src
+RUN mvn clean install
+
+
+FROM openjdk:17-alpine as run
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+
+


### PR DESCRIPTION
Ajout d'un Dockerfile qui contient les stages : 
- Build : depuis une image [Maven](https://hub.docker.com/layers/maven/library/maven/3.8.3-openjdk-17/images/sha256-9c31c89f38703a5ebe23741eb1760d88f9224b9fb5cf5e596df5549237cefd6a?context=explore). Pour installer les dépendance et packager en .jar l'application via `mvn clean install`
- Run : lance l'application depuis une image [openjdk 17](https://hub.docker.com/layers/openjdk/library/openjdk/17-alpine/images/sha256-a996cdcc040704ec6badaf5fecf1e144c096e00231a29188596c784bcf858d05?context=explore)

C'est une construction [multi stage](https://docs.docker.com/build/building/multi-stage/) permettant de clarifier les étapes de construction de l'image et par extension d'être plus maintenable.

Une fois le jar construit, il peut être utilisé sur une base plus commune comme une alpine, ici une openjdk.